### PR TITLE
Remove Instagram Link

### DIFF
--- a/app/settings/about.tsx
+++ b/app/settings/about.tsx
@@ -28,10 +28,6 @@ const AboutScreen = () => {
       url: "https://discord.gg/6KpMXts6eu",
     },
     {
-      title: "Instagram",
-      url: "https://www.instagram.com/boykotcum",
-    },
-    {
       title: "Github",
       url: "https://github.com/erayerdin/boykotcum",
     },


### PR DESCRIPTION
Instagram link is not approved due to Google Play family policies.